### PR TITLE
🎨 Palette: Make "Whispers of the Soul" accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2024-05-23 - Accessibility for Stylized Text
+**Learning:** Using stylized unicode text (like 𝖂𝖍𝖎𝖘𝖕𝖊𝖗𝖘) as interactive elements creates significant accessibility barriers. Screen readers may struggle to announce the text intelligibly, and `<span>` elements lack keyboard focus and semantic meaning.
+**Action:** When using decorative text for interactions:
+1. Wrap it in a `<button>` for semantic meaning and keyboard access.
+2. Use `aria-label` to provide the plain text version for screen readers.
+3. Reset button styles (background, border) to maintain the visual design.
+4. Add `aria-expanded` and `aria-controls` for toggle interactions.

--- a/index.html
+++ b/index.html
@@ -231,7 +231,16 @@
       color: #d5def2;
     }
 
-    .whispers-text { color: #d8a8ff; cursor: pointer; font-weight: 700; }
+    .whispers-text {
+      color: #d8a8ff;
+      cursor: pointer;
+      font-weight: 700;
+      background: transparent;
+      border: none;
+      padding: 0;
+      font-family: inherit;
+      font-size: inherit;
+    }
 
     #backToTopBtn {
       display: none;
@@ -323,7 +332,7 @@
 
     <section>
       <div class="content-card">
-        <p><span class="whispers-text" onclick="ShowHiddenText();">𝖂𝖍𝖎𝖘𝖕𝖊𝖗𝖘 𝖔𝖋 𝖙𝖍𝖊 𝕾𝖔𝖚𝖑</span></p>
+        <p><button id="whispersBtn" type="button" class="whispers-text" onclick="ShowHiddenText();" aria-expanded="false" aria-controls="HiddenTextContainer" aria-label="Whispers of the Soul">𝖂𝖍𝖎𝖘𝖕𝖊𝖗𝖘 𝖔𝖋 𝖙𝖍𝖊 𝕾𝖔𝖚𝖑</button></p>
         <div id="HiddenTextContainer" style="display: none;">Before time, from deep silence, a secret song woven of numbers, shapes, and dreams stirred, awakening the universe.</div>
       </div>
     </section>
@@ -375,8 +384,11 @@
 
     function ShowHiddenText() {
       const container = document.getElementById('HiddenTextContainer');
+      const btn = document.getElementById('whispersBtn');
       if (!container) return;
-      container.style.display = (container.style.display === 'none' || container.style.display === '') ? 'block' : 'none';
+      const isHidden = (container.style.display === 'none' || container.style.display === '');
+      container.style.display = isHidden ? 'block' : 'none';
+      if (btn) btn.setAttribute('aria-expanded', isHidden);
     }
 
     const canvas = document.getElementById('waveCanvas');


### PR DESCRIPTION
💡 What: Replaced the inaccessible `<span>` used for the "Whispers of the Soul" toggle with a semantic `<button>`.
🎯 Why: The original implementation was inaccessible to keyboard users and screen readers (due to `span` lacking semantics and the text being decorative unicode).
📸 Before/After: Visual appearance is identical (verified via screenshot), but the element is now focusable and announces correctly as "Whispers of the Soul" instead of "Mathematical bold fraktur capital W...".
♿ Accessibility: 
- Added keyboard support (Enter/Space to activate).
- Added `aria-label` for proper announcement.
- Added `aria-expanded` to indicate state.
- Added `aria-controls` to link button to content.

---
*PR created automatically by Jules for task [17019921524874519959](https://jules.google.com/task/17019921524874519959) started by @topherchris420*