### PR TITLE
🎨 Palette: Associate labels with range inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,10 +282,10 @@
         </div>
 
         <aside class="panel controls">
-          <label>Frequency <span id="freqValue">1</span></label>
+          <label for="frequency">Frequency <span id="freqValue">1</span></label>
           <input type="range" id="frequency" min="1" max="50" value="1">
 
-          <label>Amplitude <span id="ampValue">50</span></label>
+          <label for="amplitude">Amplitude <span id="ampValue">50</span></label>
           <input type="range" id="amplitude" min="10" max="100" value="50">
 
           <a href="https://archive.org/details/hemisync-gateway-5.6-exploring-focus-15/Hemisync+-+Gateway5.1+-+Advanced+Focus+12.mp3" target="_blank" id="equationBtn">


### PR DESCRIPTION
💡 What: Added `for` attributes to the Frequency and Amplitude labels in `index.html`, explicitly associating them with their corresponding `<input>` elements.

🎯 Why: To fix an accessibility issue where screen readers could not programmatically determine the label for the range sliders, and to improve usability by making the label text clickable to focus the input.

📸 Before/After: Visual appearance is unchanged, but interaction behavior is improved (clicking label focuses input).

♿ Accessibility: Ensures that range inputs have accessible names and are properly associated with their labels, complying with WCAG 2.1 Success Criterion 1.3.1 (Info and Relationships).Verified with Playwright `get_by_label`.

---
*PR created automatically by Jules for task [5602250863702805800](https://jules.google.com/task/5602250863702805800) started by @topherchris420*