### PR TITLE
🎨 Palette: Fix broken slider labels and improve focus styles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 2. Use `aria-label` to provide the plain text version for screen readers.
 3. Reset button styles (background, border) to maintain the visual design.
 4. Add `aria-expanded` and `aria-controls` for toggle interactions.
+
+## 2024-05-24 - Enhancing Range Sliders
+**Learning:** Default range sliders lack clear focus indicators in some browsers, and unassociated labels reduce click targets.
+**Action:** Always link labels with `for` attributes and ensure `input[type="range"]` has a distinct `:focus-visible` style using the brand color.

--- a/index.html
+++ b/index.html
@@ -153,6 +153,13 @@
       font-weight: 600;
       font-size: .92rem;
       margin: .85rem 0 .3rem;
+      cursor: pointer;
+    }
+
+    input[type="range"]:focus-visible {
+      outline: 2px solid var(--brand);
+      outline-offset: 2px;
+      border-radius: 4px;
     }
 
     #freqValue, #ampValue {
@@ -282,10 +289,10 @@
         </div>
 
         <aside class="panel controls">
-          <label>Frequency <span id="freqValue">1</span></label>
+          <label for="frequency">Frequency <span id="freqValue">1</span></label>
           <input type="range" id="frequency" min="1" max="50" value="1">
 
-          <label>Amplitude <span id="ampValue">50</span></label>
+          <label for="amplitude">Amplitude <span id="ampValue">50</span></label>
           <input type="range" id="amplitude" min="10" max="100" value="50">
 
           <a href="https://archive.org/details/hemisync-gateway-5.6-exploring-focus-15/Hemisync+-+Gateway5.1+-+Advanced+Focus+12.mp3" target="_blank" id="equationBtn">


### PR DESCRIPTION
💡 What: Added `for` attributes to the Frequency and Amplitude labels and introduced a `:focus-visible` style for range inputs matching the brand color.
🎯 Why: Mouse users couldn't click labels to focus sliders, and keyboard users lacked a clear focus indicator on these controls.
📸 Before/After: Labels were unassociated text; now they are interactive. Sliders had default focus rings; now they use `--brand` color.
♿ Accessibility: Ensures proper label association for screen readers and improves keyboard navigation visibility.

---
*PR created automatically by Jules for task [8208662344523231735](https://jules.google.com/task/8208662344523231735) started by @topherchris420*